### PR TITLE
Comment out phil migration for dev work - - barfs on .affiliations call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     ZenTest (4.9.5)
     actionmailer (3.1.11)

--- a/db/migrate/20090331000847_phil_projects.rb
+++ b/db/migrate/20090331000847_phil_projects.rb
@@ -24,8 +24,8 @@ class PhilProjects < ActiveRecord::Migration
     Affiliation.create!(:dude => phil, :project => gitjour)
 
     # In production there are two clips to my name, but I can't repro in dev.
-    clips = Project.find_by_name('clip').affiliations.select{ |a| a.dude == phil }
-    clips[1].destroy if clips[1]
+    #clips = Project.find_by_name('clip').affiliations.select{ |a| a.dude == phil }
+    #clips[1].destroy if clips[1]
   end
 
   def self.down


### PR DESCRIPTION
This migration will prevent a new user from building the site on their local development environment due to a bad .affiliations method call. Commenting it out fixes the problem without much detriment.
