### PR TITLE
Truncate Description with more link Issue #64

### DIFF
--- a/app/views/talks/index.html.erb
+++ b/app/views/talks/index.html.erb
@@ -39,8 +39,8 @@
         <h4><%= link_to talk.title, talk %></h4>
         <div><%= indefinite_Articlerize talk.kind %> talk proposed by <%= talk.presenter %></div>
         <p class="description">
-          <%= talk.description.truncate(200, separator: ' ', omission: "...") %>
-          <%= if talk.description.length > 200 then link_to("read more", talk) end %>
+          <%= talk.description.truncate(200, separator: ' ', omission: "...") unless talk.description.nil? %>
+          <%= if talk.description.length > 200 then link_to("read more", talk) end unless talk.description.nil? %>
         </p>
       </div>
     <% end %>


### PR DESCRIPTION
This is for Issue #64 "Make large descriptions more friendly to other talks"

Does this work?  This truncates with ... if the description length is more than 200 characters.  It then creates a more link if the description length is greater than 200 characters.
