### PR TITLE
available locales. #63

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,9 @@ module SeattlerbOrg
     config.time_zone = 'UTC'
 
     config.active_record.whitelist_attributes = false
+
+    config.i18n.enforce_available_locales = true
+    config.i18n.available_locales = [:en]
   end
 end
 


### PR DESCRIPTION
Fixes i18n warnings.

Set the enforce_available_locales to true (default) in the future.
Set the available locales to only english.

Fixes issue #63
