### PR TITLE
dates in event dropdown for talks admin

### DIFF
--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -4,4 +4,6 @@ RailsAdmin.config do |config|
   config.current_user_method { current_admin }
 
   config.main_app_name = ['Seattle.rb', 'Admin']
+
+  config.label_methods << :date
 end


### PR DESCRIPTION
Add date as object_label_method for RailsAdmin so that admin can connect a talk to an event by its date instead of id. Closes #78
