### PR TITLE
Remove custom travis setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,4 @@ rvm:
   - 2.0.0
 cache: bundler
 script:
-  - RAILS_ENV=test bundle exec rake
-before_script:
-  - RAILS_ENV=test bundle exec rake db:schema:load
-  - RAILS_ENV=test bundle exec rake db:test:prepare
+  - bundle exec rake db:migrate test


### PR DESCRIPTION
~~This is a WIP because I have to open a PR to get Travis to run a build.~~ Ok this looks ready to go.

I originally setup Travis to skip running migrations and load the schema directly because our migrations wouldn't run from start to finish on a clean database. Now we have the migrations sorted out, but we [have no schema.rb](https://github.com/seattlerb/seattlerb.org/commit/4dac56fd06d716a0334dea1cf6b00ce328506aef). 

This PR undoes the custom Travis setup and uses a more vanilla config.