### PR TITLE
When creating talk, can add optional event date - Fixes #33

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -57,6 +57,6 @@ class TalksController < ApplicationController
   end
 
   def talk_params
-    params.require(:talk).permit(:title, :description, :presenter, :kind, :email, :spam, :special_talk_requests)
+    params.require(:talk).permit(:title, :description, :presenter, :kind, :email, :spam, :special_talk_requests, :event_id)
   end
 end

--- a/app/views/talks/_form.html.erb
+++ b/app/views/talks/_form.html.erb
@@ -16,7 +16,9 @@
     <%= f.text_field :email,       :placeholder => "Email (private!)"        %><br />
     <%= f.text_field :title,       :placeholder => "Title"                   %><br />
     <%= f.text_area  :description, :placeholder => "Description", :rows => 3 %><br />
-    <%= f.select :kind, talk_kinds %>
+    <%= f.select :kind, talk_kinds %><br />
+    <%= f.label :event_id, "Proposed Date" %>
+    <%= f.collection_select :event_id, Event.where("date > ?", Date.current), :id, :date, include_blank: :true %>
 
     <%= hidden_field_tag :password, "" %>
     <p style="width: 1px; height: 1px; overflow: hidden;">


### PR DESCRIPTION
Hi @phiggins,

Does this look alright?  This allows people to optionally select an event date.  One thing though, when someone selects an event date, it will then show as the 'Scheduled' date below.  Should we take out the 'Scheduled' portion of the text or add a way to confirm the date?

Locally on my machine, only the next event is created and available in the db.  If several future events aren't available, should we add a scheduled task to ensure the next several events are created?

![image](https://cloud.githubusercontent.com/assets/527139/6703385/6aa095a4-ccf8-11e4-8693-6c955ccbee37.png)
