### PR TITLE
Update TravisCI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: ruby
 rvm:
   - 2.0.0
 cache: bundler
+sudo: false
 script:
   - bundle exec rake db:migrate test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rvm:
   - 2.0.0
 cache: bundler
 sudo: false
-script:
-  - bundle exec rake db:migrate test
+before_script:
+  bundle exec rake db:create db:migrate


### PR DESCRIPTION
The `sudo: false` bit lets us use Travis's newer setup for faster builds: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/

The builds start waaaaaayyyy faster with that on.

The `before_script:` malarkey was to get CI to cooperate with #117.