### PR TITLE
changed rubygems.org url to use https

### DIFF
--- a/app/validators/rubygems_validator.rb
+++ b/app/validators/rubygems_validator.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 class RubygemsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    uri = URI("http://rubygems.org/api/v1/owners/#{value}/gems.json")
+    uri = URI("https://rubygems.org/api/v1/owners/#{value}/gems.json")
 
     unless Net::HTTPSuccess === Net::HTTP.get_response(uri) then
       record.errors[attribute] << (options[:message] || "user isn't found" )


### PR DESCRIPTION
This fixes some tests that were failing and, by extension, the validator.  The original url format would redirect to the https version but it could not handle that so it would always fail.