### PR TITLE
Fixed issue with rubygems.org https redirect

### DIFF
--- a/app/validators/rubygems_validator.rb
+++ b/app/validators/rubygems_validator.rb
@@ -3,7 +3,7 @@ require 'uri'
 
 class RubygemsValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    uri = URI("http://rubygems.org/api/v1/owners/#{value}/gems.json")
+    uri = URI("https://rubygems.org/api/v1/owners/#{value}/gems.json")
 
     unless Net::HTTPSuccess === Net::HTTP.get_response(uri) then
       record.errors[attribute] << (options[:message] || "user isn't found" )


### PR DESCRIPTION
Some tests were failing due to a redirect to the https version.  It expects a success if the validation is true but gets a redirect every time so the validation would always fail.