### PR TITLE
UrlValidator should mark URLs w/ crap in them as invalid.

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,7 +1,14 @@
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless URI.parse(value).kind_of?(URI::HTTP)
-      record.errors[attribute] << (options[:message] || "is an invalid URL")
-    end   
+    return true if valid_url?(value)
+    record.errors[attribute] << options.fetch(:message, 'is an invalid URL')
   end
+
+  private
+
+    def valid_url?(value)
+      URI.parse(value).kind_of?(URI::HTTP)
+    rescue URI::InvalidURIError
+      false
+    end
 end

--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -105,6 +105,14 @@ class MemberTest < ActiveSupport::TestCase
     refute member.valid?
   end
 
+  def test_crap_in_url
+    member = Member.new(:name    => "Member",
+                        :website => "http://www.google.com (lulz not rly)",
+                        :email => "pete@gmail.com",
+                        :password => "password1234")
+    refute member.valid?
+  end
+
   def test_bio
     with_bio    = Member.create!(:name         => "with_bio",
                                  :ruby_gems_id => "aaronp",


### PR DESCRIPTION
Currently, if you enter a string like 'http://example.com/ (this is kinda crappy)' as your website, the UrlValidator throws `URI::InvalidURIError` which was not previously rescued. The validator now raises that error and marks the record as invalid in two cases:

 1. When there is a crappy URL per above; and
 2. When a non-HTTP URL is entered as a website