### PR TITLE
Remove ruby_gems_id to prevent http calls in test.

### DIFF
--- a/test/models/member_test.rb
+++ b/test/models/member_test.rb
@@ -115,12 +115,10 @@ class MemberTest < ActiveSupport::TestCase
 
   def test_bio
     with_bio    = Member.create!(:name         => "with_bio",
-                                 :ruby_gems_id => "aaronp",
                                  :email        => "test1@test.com",
                                  :bio          => "Bio",
                                  :password     => "password1234")
     without_bio = Member.create!(:name         => "without_bio",
-                                 :ruby_gems_id => "qrush",
                                  :email        => "test@test.com",
                                  :password     => "password82")
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -15,7 +15,6 @@ class ProjectTest < ActiveSupport::TestCase
     p = Project.create!(:name => "My Test Project")
     d = Member.create!(:name => "John",
                        :email => "test@test.com",
-                       :ruby_gems_id => "qrush",
                        :password => "password1234")
 
     d.projects << p


### PR DESCRIPTION
Setting ruby_gems_id when it wasn't necessary for the test was doing http calls for tests that didn't need to.