### PR TITLE
Allow admin to edit Member without supplying user's password

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -5,6 +5,15 @@ class Member < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
   NONE = "missing_image.png"
 
+  rails_admin do
+    configure :set_password
+
+    edit do
+      exclude_fields :password, :password_confirmation
+      include_fields :set_password
+    end
+  end
+
   attr_accessor :username # fake attribute for spam trapping
   validates_length_of :username, :maximum => 0
 
@@ -24,6 +33,14 @@ class Member < ActiveRecord::Base
   before_save :set_avatar, if: Proc.new { |user|
     user.respond_to?(:twitter_changed?) and user.twitter_changed?
   }
+
+   def set_password; nil; end
+
+   def set_password=(value)
+     return nil if value.blank?
+     self.password = value
+     self.password_confirmation = value
+   end
 
   def bio
     bio = self['bio']


### PR DESCRIPTION
See:
https://github.com/sferik/rails_admin/issues/2265#issuecomment-102791278

Prior to this change, verifying a member failed due to password
constraints on the underlying model.

This change adds rails_admin  configuration to prevent password fields
from being considered for editing. Additionally, this changes the admin
console to allow an admin to reset a member’s password via the
administrative interface.