### PR TITLE
Fix slack signup

### DIFF
--- a/app/views/about/_slack.html.erb
+++ b/app/views/about/_slack.html.erb
@@ -2,10 +2,7 @@
   <div id="map" class='span12'>
     <div id="info" class='span4'>
       <h1>Slack</h1>
-      We have a Slack organization where you can ask questions and discuss programming topics. Join us!
-    </div>
-    <div class='span8'>
-      <iframe height="275" frameborder="" scrolling="no" marginheight="0" marginwidth="0" src="http://slack.seattlerb.org/iframe/dialog"></iframe>
+      <%= link_to "Join Our Slack!", "https://join.slack.com/t/seattlerb/shared_invite/zt-n9ut2ybq-uTabTrrGbYbzIcbXvIxH0g" %>
     </div>
   </div>
 </div>

--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -25,7 +25,9 @@
   <div class="span4">
     <h2>How Can I Participate?</h2>
     <p>
-      The Tuesday "Nerd Party" is informal - drop in and code with us as you please. We host larger, formal events on a monthly basis. We're also on <%= link_to "Slack here", "http://slack.seattlerb.org" %>. We encourage everyone, from Ruby novice to expert, to join us to learn and contribute. We're excited to grow and support the Ruby and Rails communities.
+      The Tuesday "Nerd Party" is informal - drop in and code with us as you please. We host larger, formal events on a monthly basis. We're also on
+      <%= link_to "Slack here", "https://join.slack.com/t/seattlerb/shared_invite/zt-n9ut2ybq-uTabTrrGbYbzIcbXvIxH0g" %>.
+      We encourage everyone, from Ruby novice to expert, to join us to learn and contribute. We're excited to grow and support the Ruby and Rails communities.
     </p>
     <p>
       So <%= link_to "join us", join_us_path %> and <%= link_to "sign up to give a talk", talks_path %>!


### PR DESCRIPTION
Remove all references to slack.seattlerb.org and swapped in a permanent link to join