### PR TITLE
Fix up navbar styles

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,12 +32,15 @@
      }
 
      footer, header, main { padding: 1rem 1rem; }
-     nav { margin-bottom: 0; }
+     nav  {
+       margin-bottom: 0;
+       & ul { display: flex; };
+     }
      mark { background: var(--color-secondary-accent); }
      h1, h2, h3, h4, h5, h6 { color: var(--seattle); }
 
      header nav img {
-         margin: 0;
+         margin: 0 0.5em 0 0;
          vertical-align: middle;
      }
 
@@ -68,12 +71,12 @@
     <header>
       <nav>
         <ul>
-          <%= content_tag :li, link_to(image_tag('seattle.rb_logo.png', size:"45x40") + " Seattle.rb", root_path, id: "seattlerblogo") %>
+          <%= content_tag :li, link_to(image_tag('seattle.rb_logo.png', size:"45x40") + "Seattle.rb", root_path, id: "seattlerblogo") %>
         </ul>
         <ul>
         <%= nav_item_link "People", users_path %>
         <%= nav_item_link "Projects", projects_path %>
-        <%= nav_item_link "Join Us", join_us_path %>
+        <%= nav_item_link "Join&nbsp;Us".html_safe, join_us_path %>
         <%#= nav_item_link "Talks", talks_path %>
         <%#= nav_item_link "Blog", posts_path %>
         <%= nav_item_link "Values", values_path %>


### PR DESCRIPTION
1. Remove the underline between logo and Seattle.
2. Make the nav items more horizontal on smaller screens.

## Before

iPhone 17 browser emulation.

<img width="806" height="500" alt="image" src="https://github.com/user-attachments/assets/a16cdb97-06f1-42db-a7d9-52cc5d882de2" />


## After

<img width="804" height="300" alt="image" src="https://github.com/user-attachments/assets/0c3ce9a7-64f9-4c7a-bd34-5d49baa2e645" />
